### PR TITLE
Enforce MFA setup and verification on login

### DIFF
--- a/app/mfa/page.tsx
+++ b/app/mfa/page.tsx
@@ -2,7 +2,7 @@
 
 import { enrollMFA } from "@/lib/actions/mfa/enrollMfa";
 import { verifyMFA } from "@/lib/actions/mfa/verifyMfa";
-import { useState, use } from "react";
+import { useState, useEffect, use } from "react";
 
 export default function MFA({
   searchParams,
@@ -19,17 +19,14 @@ export default function MFA({
     setQrCode(mfa.totp.qr_code);
   };
 
+  useEffect(() => {
+    handleEnrollMFA();
+  }, []);
+
   return (
     <>
       <div className="pt-0 p-3 border border-white w-full h-[84vh] flex justify-between items-center">
-        <div className="flex justify-center items-center border border-white w-[20vw] h-[50vh]">
-          <button
-            onClick={() => handleEnrollMFA()}
-            className="bg-white text-black px-4 py-2 rounded-2xl mb-3"
-          >
-            Enable 2FA
-          </button>
-        </div>
+        <div className="flex justify-center items-center border border-white w-[20vw] h-[50vh]" />
         <div className="border border-white w-[80vw] h-[50vh]">
           <div className="w-full mx-auto flex items-center justify-center gap-7 border border-red-200 h-full">
             {qrCode && (

--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -12,6 +12,19 @@ export default async function ProtectedPage() {
     redirect("/auth/login");
   }
 
+  const { data: factors } = await supabase.auth.mfa.listFactors();
+  if (!factors?.all.length) {
+    redirect("/mfa");
+  }
+
+  const assuranceLevel = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+  if (
+    assuranceLevel.data?.nextLevel === "aal2" &&
+    assuranceLevel.data?.nextLevel !== assuranceLevel.data?.currentLevel
+  ) {
+    redirect("/verify-mfa");
+  }
+
   return (
     <div className="flex-1 w-full flex flex-col gap-12">
       <div className="w-full">

--- a/app/protected/settings/page.tsx
+++ b/app/protected/settings/page.tsx
@@ -251,15 +251,7 @@ export default function Settings() {
             </form>
           )}
 
-          {hasMfa && !qrCodeUrl && (
-            <Button
-              variant="destructive"
-              onClick={handleUnenroll}
-              className="self-start"
-            >
-              Disable 2FA
-            </Button>
-          )}
+
 
           {message && (
             <p className="text-sm text-red-500 mt-4">{message}</p>

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -39,14 +39,19 @@ export function LoginForm({
       });
       if (error) throw error;
 
-      const assuranceLevel = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-      if (
-        assuranceLevel.data?.nextLevel === "aal2" &&
-        assuranceLevel.data?.nextLevel !== assuranceLevel.data?.currentLevel
-      ) {
-        router.push("/verify-mfa");
+      const { data: factors } = await supabase.auth.mfa.listFactors();
+      if (!factors?.all.length) {
+        router.push("/mfa");
       } else {
-        router.push("/protected");
+        const assuranceLevel = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+        if (
+          assuranceLevel.data?.nextLevel === "aal2" &&
+          assuranceLevel.data?.nextLevel !== assuranceLevel.data?.currentLevel
+        ) {
+          router.push("/verify-mfa");
+        } else {
+          router.push("/protected");
+        }
       }
     } catch (error: unknown) {
       setError(error instanceof Error ? error.message : "An error occurred");


### PR DESCRIPTION
## Summary
- force MFA enrollment right after login by checking enrolled factors
- auto-enroll MFA on the `/mfa` page and remove the setup button
- prevent disabling MFA in settings
- restrict access to protected pages when MFA is not verified

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b7d131504832fb4c5cbf684aa7d30