### PR TITLE
Handle MFA factor reuse and add recovery email option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,15 @@ If you wish to just develop locally and not deploy to Vercel, [follow the steps 
    ```
    NEXT_PUBLIC_SUPABASE_URL=[INSERT SUPABASE PROJECT URL]
    NEXT_PUBLIC_SUPABASE_ANON_KEY=[INSERT SUPABASE PROJECT API ANON KEY]
+   SMTP_HOST=[YOUR SMTP HOST]
+   SMTP_PORT=[YOUR SMTP PORT]
+   SMTP_USER=[YOUR SMTP USER]
+   SMTP_PASS=[YOUR SMTP PASSWORD]
+   MFA_EMAIL_FROM=[SENDER EMAIL ADDRESS]
    ```
 
    Both `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` can be found in [your Supabase project's API settings](https://supabase.com/dashboard/project/_?showConnect=true)
+   The SMTP variables are used to send a recovery email containing a new MFA QR code if a user loses access to their authenticator device.
 
 5. You can now run the Next.js local development server:
 

--- a/app/verify-mfa/page.tsx
+++ b/app/verify-mfa/page.tsx
@@ -4,11 +4,22 @@
 import { useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { verifyMFA } from '@/lib/actions/mfa/verifyMfa';
+import { recoverMFA } from '@/lib/actions/mfa/recoverMfa';
 
 export default function MfaVerification() {
   const searchParams = useSearchParams();
   const message = searchParams.get('message') || undefined;
   const [showMessage, setShowMessage] = useState(true);
+  const [recoveryMsg, setRecoveryMsg] = useState<string | null>(null);
+
+  const handleRecovery = async () => {
+    try {
+      await recoverMFA();
+      setRecoveryMsg('Recovery email sent. Check your inbox.');
+    } catch (err) {
+      setRecoveryMsg('Unable to send recovery email');
+    }
+  };
 
   return (
     <div className="min-h-screen bg-white flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
@@ -59,6 +70,16 @@ export default function MfaVerification() {
           >
             Verify
           </button>
+          <button
+            type="button"
+            onClick={handleRecovery}
+            className="w-full py-2 px-4 border border-gray-300 rounded-md text-sm mt-4"
+          >
+            Send recovery email
+          </button>
+          {recoveryMsg && (
+            <p className="text-center text-sm text-gray-700 mt-2">{recoveryMsg}</p>
+          )}
         </form>
       </div>
     </div>

--- a/lib/actions/mfa/enrollMfa.ts
+++ b/lib/actions/mfa/enrollMfa.ts
@@ -2,11 +2,39 @@
 
 import { createClient } from '@/lib/supabase/server.server'
 
+interface MfaEnrollData {
+  id: string
+  type: 'totp' | (string & {})
+  totp: {
+    qr_code: string
+    secret: string
+    uri: string
+  }
+  friendly_name?: string
+}
+
 export const enrollMFA = async () => {
   const supabase = await createClient()
 
   // Check current assurance level before enrolling
   await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+
+  const factors = await supabase.auth.mfa.listFactors()
+  if (factors.error) {
+    throw factors.error
+  }
+
+  const existing = factors.data.all.find((f) => f.factor_type === 'totp')
+
+  if (existing) {
+    if (existing.status === 'unverified') {
+      // Remove unverified factor before re-enrolling
+      await supabase.auth.mfa.unenroll({ factorId: existing.id })
+    } else {
+      // Already enrolled and verified
+      return { alreadyEnrolled: true }
+    }
+  }
 
   const { data, error } = await supabase.auth.mfa.enroll({
     factorType: 'totp',
@@ -18,5 +46,5 @@ export const enrollMFA = async () => {
   // Optionally check assurance level after enrolling
   await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
 
-  return data
+  return data as MfaEnrollData
 }

--- a/lib/actions/mfa/recoverMfa.ts
+++ b/lib/actions/mfa/recoverMfa.ts
@@ -1,0 +1,49 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server.server'
+import nodemailer from 'nodemailer'
+
+export const recoverMFA = async () => {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    throw new Error('Not authenticated')
+  }
+
+  const factors = await supabase.auth.mfa.listFactors()
+  if (factors.error) {
+    throw factors.error
+  }
+  const existing = factors.data.all.find((f) => f.factor_type === 'totp')
+  if (existing) {
+    await supabase.auth.mfa.unenroll({ factorId: existing.id })
+  }
+
+  const { data, error } = await supabase.auth.mfa.enroll({ factorType: 'totp' })
+  if (error || !data) {
+    throw error || new Error('Enroll failed')
+  }
+
+  if (process.env.SMTP_HOST && process.env.MFA_EMAIL_FROM && user.email) {
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT ?? '587'),
+      secure: false,
+      auth: process.env.SMTP_USER
+        ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+        : undefined,
+    })
+
+    await transporter.sendMail({
+      from: process.env.MFA_EMAIL_FROM,
+      to: user.email,
+      subject: 'Recover your MFA setup',
+      html: `<p>Scan this QR code with your authenticator app.</p><img src="${data.totp.qr_code}" alt="MFA QR Code" />`,
+    })
+  }
+
+  return { sent: true }
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-qr-code": "^2.0.18",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "nodemailer": "^6.9.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- avoid MFA enrollment errors by checking existing factors
- allow unenrolling unverified factor and re-enrolling
- add MFA recovery action that emails a fresh QR code via nodemailer
- expose a recovery button on the verification page
- document SMTP environment variables for recovery emails
- add nodemailer dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b91093e88832f9e980fda3198ffab