### PR TITLE
Improve MFA recovery error handling

### DIFF
--- a/app/verify-mfa/page.tsx
+++ b/app/verify-mfa/page.tsx
@@ -14,8 +14,12 @@ export default function MfaVerification() {
 
   const handleRecovery = async () => {
     try {
-      await recoverMFA();
-      setRecoveryMsg('Recovery email sent. Check your inbox.');
+      const result = await recoverMFA();
+      if (result.sent) {
+        setRecoveryMsg('Recovery email sent. Check your inbox.');
+      } else {
+        setRecoveryMsg(result.error ?? 'Unable to send recovery email');
+      }
     } catch (err) {
       setRecoveryMsg('Unable to send recovery email');
     }

--- a/lib/actions/mfa/recoverMfa.ts
+++ b/lib/actions/mfa/recoverMfa.ts
@@ -28,21 +28,26 @@ export const recoverMFA = async () => {
   }
 
   if (process.env.SMTP_HOST && process.env.MFA_EMAIL_FROM && user.email) {
-    const transporter = nodemailer.createTransport({
-      host: process.env.SMTP_HOST,
-      port: Number(process.env.SMTP_PORT ?? '587'),
-      secure: false,
-      auth: process.env.SMTP_USER
-        ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
-        : undefined,
-    })
+    try {
+      const transporter = nodemailer.createTransport({
+        host: process.env.SMTP_HOST,
+        port: Number(process.env.SMTP_PORT ?? '587'),
+        secure: false,
+        auth: process.env.SMTP_USER
+          ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+          : undefined,
+      })
 
-    await transporter.sendMail({
-      from: process.env.MFA_EMAIL_FROM,
-      to: user.email,
-      subject: 'Recover your MFA setup',
-      html: `<p>Scan this QR code with your authenticator app.</p><img src="${data.totp.qr_code}" alt="MFA QR Code" />`,
-    })
+      await transporter.sendMail({
+        from: process.env.MFA_EMAIL_FROM,
+        to: user.email,
+        subject: 'Recover your MFA setup',
+        html: `<p>Scan this QR code with your authenticator app.</p><img src="${data.totp.qr_code}" alt="MFA QR Code" />`,
+      })
+    } catch (err) {
+      console.error('Error sending recovery email:', err)
+      return { sent: false, error: (err as Error).message }
+    }
   }
 
   return { sent: true }


### PR DESCRIPTION
## Summary
- handle Nodemailer failures gracefully in `recoverMfa`
- display recovery email errors to users on the MFA verification page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9b8bbe08832fb6208ca268920e09