### PR TITLE
Update supabase client imports

### DIFF
--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/admin.server";
+import { createClient } from "@/lib/supabase/client";
 import { type EmailOtpType } from "@supabase/supabase-js";
 import { redirect } from "next/navigation";
 import { type NextRequest } from "next/server";
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
   const next = searchParams.get("next") ?? "/";
 
   if (token_hash && type) {
-    const supabase = await createClient();
+    const supabase = createClient();
 
     const { error } = await supabase.auth.verifyOtp({
       type,

--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -1,11 +1,11 @@
 import { redirect } from "next/navigation";
 
-import { createClient } from "@/lib/supabase/admin.server";
+import { createClient } from "@/lib/supabase/client";
 import { InfoIcon } from "lucide-react";
 import { FetchDataSteps } from "@/components/tutorial/fetch-data-steps";
 
 export default async function ProtectedPage() {
-  const supabase = await createClient();
+  const supabase = createClient();
 
   const { data, error } = await supabase.auth.getUser();
   if (error || !data?.user) {

--- a/components/auth-button.tsx
+++ b/components/auth-button.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
 import { Button } from "./ui/button";
-import { createClient } from "@/lib/supabase/admin.server";
+import { createClient } from "@/lib/supabase/client";
 import { LogoutButton } from "./logout-button";
 
 export async function AuthButton() {
-  const supabase = await createClient();
+  const supabase = createClient();
 
   const {
     data: { user },

--- a/lib/actions/mfa/checkAssuranceLevel.ts
+++ b/lib/actions/mfa/checkAssuranceLevel.ts
@@ -1,8 +1,8 @@
 'use server'
 
-import { createClient } from '@/lib/supabase/admin.server'
+import { createClient } from '@/lib/supabase/client'
 
 export const checkAssurance = async () => {
-  const supabase = await createClient()
+  const supabase = createClient()
   await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
 }

--- a/lib/actions/mfa/enrollMfa.ts
+++ b/lib/actions/mfa/enrollMfa.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { createClient } from '@/lib/supabase/admin.server'
+import { createClient } from '@/lib/supabase/client'
 
 interface MfaEnrollData {
   id: string
@@ -14,7 +14,7 @@ interface MfaEnrollData {
 }
 
 export const enrollMFA = async () => {
-  const supabase = await createClient()
+  const supabase = createClient()
 
   // Check current assurance level before enrolling
   await supabase.auth.mfa.getAuthenticatorAssuranceLevel()

--- a/lib/actions/mfa/unEnrollMfa.ts
+++ b/lib/actions/mfa/unEnrollMfa.ts
@@ -1,9 +1,9 @@
 'use server'
 
-import { createClient } from '@/lib/supabase/admin.server'
+import { createClient } from '@/lib/supabase/client'
 
 export const unEnrollMFA = async () => {
-  const supabase = await createClient()
+  const supabase = createClient()
 
   const factors = await supabase.auth.mfa.listFactors()
   if (factors.error) {

--- a/lib/actions/mfa/verifyMfa.ts
+++ b/lib/actions/mfa/verifyMfa.ts
@@ -1,7 +1,7 @@
 // lib/actions/mfa/verifyMfa.ts
 'use server'
 
-import { createClient } from '@/lib/supabase/admin.server'
+import { createClient } from '@/lib/supabase/client'
 
 export interface VerifyMFAResult {
   success: boolean
@@ -13,7 +13,7 @@ export async function verifyMFA({
 }: {
   verifyCode: string
 }): Promise<VerifyMFAResult> {
-  const supabase = await createClient()
+  const supabase = createClient()
 
   if (!verifyCode) {
     return { success: false, error: 'Missing verification code' }


### PR DESCRIPTION
## Summary
- use `createClient` from `@/lib/supabase/client`
- remove `await` when calling `createClient`

## Testing
- `npm run lint` *(fails: `handleUnenroll` unused, `Button` unused, `no-explicit-any`)*

------
https://chatgpt.com/codex/tasks/task_e_686ba738a064832faf94c621bc593e3c