### PR TITLE
Update supabase client imports

### DIFF
--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/admin.server";
+import { createClient } from "@/lib/supabase/client";
 import { type EmailOtpType } from "@supabase/supabase-js";
 import { redirect } from "next/navigation";
 import { type NextRequest } from "next/server";

--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 
-import { createClient } from "@/lib/supabase/admin.server";
+import { createClient } from "@/lib/supabase/client";
 import { InfoIcon } from "lucide-react";
 import { FetchDataSteps } from "@/components/tutorial/fetch-data-steps";
 

--- a/components/auth-button.tsx
+++ b/components/auth-button.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Button } from "./ui/button";
-import { createClient } from "@/lib/supabase/admin.server";
+import { createClient } from "@/lib/supabase/client";
 import { LogoutButton } from "./logout-button";
 
 export async function AuthButton() {

--- a/lib/actions/mfa/checkAssuranceLevel.ts
+++ b/lib/actions/mfa/checkAssuranceLevel.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { createClient } from '@/lib/supabase/admin.server'
+import { createClient } from '@/lib/supabase/client'
 
 export const checkAssurance = async () => {
   const supabase = await createClient()

--- a/lib/actions/mfa/enrollMfa.ts
+++ b/lib/actions/mfa/enrollMfa.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { createClient } from '@/lib/supabase/admin.server'
+import { createClient } from '@/lib/supabase/client'
 
 interface MfaEnrollData {
   id: string

--- a/lib/actions/mfa/unEnrollMfa.ts
+++ b/lib/actions/mfa/unEnrollMfa.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { createClient } from '@/lib/supabase/admin.server'
+import { createClient } from '@/lib/supabase/client'
 
 export const unEnrollMFA = async () => {
   const supabase = await createClient()

--- a/lib/actions/mfa/verifyMfa.ts
+++ b/lib/actions/mfa/verifyMfa.ts
@@ -1,7 +1,7 @@
 // lib/actions/mfa/verifyMfa.ts
 'use server'
 
-import { createClient } from '@/lib/supabase/admin.server'
+import { createClient } from '@/lib/supabase/client'
 
 export interface VerifyMFAResult {
   success: boolean


### PR DESCRIPTION
## Summary
- refactor imports to use client supabase helper

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba70d5a5c832faf84278cbdab0c23