### PR TITLE
Fix import paths for tutorial fetch step

### DIFF
--- a/components/tutorial/fetch-data-steps.tsx
+++ b/components/tutorial/fetch-data-steps.tsx
@@ -13,7 +13,7 @@ values
   ('It was awesome!');
 `.trim();
 
-const server = `import { createClient } from '@/utils/supabase/server'
+const server = `import { createClient } from '@/lib/supabase/client'
 
 export default async function Page() {
   const supabase = await createClient()
@@ -25,7 +25,7 @@ export default async function Page() {
 
 const client = `'use client'
 
-import { createClient } from '@/utils/supabase/client'
+import { createClient } from '@/lib/supabase/client'
 import { useEffect, useState } from 'react'
 
 export default function Page() {


### PR DESCRIPTION
## Summary
- update import paths in fetch-data-steps.tsx to use `@/lib/supabase/client`

## Testing
- `npm run lint` *(fails: `no-img-element` warnings and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_686ba71596f0832fbe0156c5c5a6d14b