### PR TITLE
Add browser Supabase client

### DIFF
--- a/app/protected/settings/page.tsx
+++ b/app/protected/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState, FormEvent } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { createClient } from '@/lib/supabase/client'
+import { createClient } from '@/lib/supabase/browser'
 
 // ——— Typed ShadCN‐style UI components (same as before) ———
 type DivProps = React.HTMLAttributes<HTMLDivElement>

--- a/components/forgot-password-form.tsx
+++ b/components/forgot-password-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { createClient } from "@/lib/supabase/client";
+import { createClient } from "@/lib/supabase/browser";
 import { Button } from "@/components/ui/button";
 import {
   Card,

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { createClient } from "@/lib/supabase/client";
+import { createClient } from "@/lib/supabase/browser";
 import { Button } from "@/components/ui/button";
 import {
   Card,

--- a/components/logout-button.tsx
+++ b/components/logout-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createClient } from "@/lib/supabase/client";
+import { createClient } from "@/lib/supabase/browser";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
 

--- a/components/sign-up-form.tsx
+++ b/components/sign-up-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { createClient } from "@/lib/supabase/client";
+import { createClient } from "@/lib/supabase/browser";
 import { Button } from "@/components/ui/button";
 import {
   Card,

--- a/components/update-password-form.tsx
+++ b/components/update-password-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { createClient } from "@/lib/supabase/client";
+import { createClient } from "@/lib/supabase/browser";
 import { Button } from "@/components/ui/button";
 import {
   Card,

--- a/lib/supabase/browser.ts
+++ b/lib/supabase/browser.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from '@supabase/ssr'
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  )
+}


### PR DESCRIPTION
## Summary
- introduce a browser-friendly Supabase client using `createBrowserClient`
- update client components to use this browser client

## Testing
- `npm run lint` *(fails: `handleUnenroll` is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_686ba7236eb0832fb084bf803c868940