### PR TITLE
Make Supabase server client async

### DIFF
--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
   const next = searchParams.get("next") ?? "/";
 
   if (token_hash && type) {
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { error } = await supabase.auth.verifyOtp({
       type,

--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -5,7 +5,7 @@ import { InfoIcon } from "lucide-react";
 import { FetchDataSteps } from "@/components/tutorial/fetch-data-steps";
 
 export default async function ProtectedPage() {
-  const supabase = createClient();
+  const supabase = await createClient();
 
   const { data, error } = await supabase.auth.getUser();
   if (error || !data?.user) {

--- a/components/auth-button.tsx
+++ b/components/auth-button.tsx
@@ -4,7 +4,7 @@ import { createClient } from "@/lib/supabase/client";
 import { LogoutButton } from "./logout-button";
 
 export async function AuthButton() {
-  const supabase = createClient();
+  const supabase = await createClient();
 
   const {
     data: { user },

--- a/lib/actions/mfa/checkAssuranceLevel.ts
+++ b/lib/actions/mfa/checkAssuranceLevel.ts
@@ -3,6 +3,6 @@
 import { createClient } from '@/lib/supabase/client'
 
 export const checkAssurance = async () => {
-  const supabase = createClient()
+  const supabase = await createClient()
   await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
 }

--- a/lib/actions/mfa/enrollMfa.ts
+++ b/lib/actions/mfa/enrollMfa.ts
@@ -14,7 +14,7 @@ interface MfaEnrollData {
 }
 
 export const enrollMFA = async () => {
-  const supabase = createClient()
+  const supabase = await createClient()
 
   // Check current assurance level before enrolling
   await supabase.auth.mfa.getAuthenticatorAssuranceLevel()

--- a/lib/actions/mfa/recoverMfa.tsx
+++ b/lib/actions/mfa/recoverMfa.tsx
@@ -14,7 +14,7 @@ interface RecoverMFAResult {
 
 export const recoverMFA = async (): Promise<RecoverMFAResult> => {
   // 1) Build both clients
-  const userClient  = createClient()
+  const userClient  = await createClient()
   const adminClient = createAdminClient()
 
   // 2) Make sure the user is authenticated

--- a/lib/actions/mfa/unEnrollMfa.ts
+++ b/lib/actions/mfa/unEnrollMfa.ts
@@ -3,7 +3,7 @@
 import { createClient } from '@/lib/supabase/client'
 
 export const unEnrollMFA = async () => {
-  const supabase = createClient()
+  const supabase = await createClient()
 
   const factors = await supabase.auth.mfa.listFactors()
   if (factors.error) {

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,8 +1,8 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
-export function createClient() {
-  const cookieStore = cookies()
+export async function createClient() {
+  const cookieStore = await cookies()
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
## Summary
- handle async cookie retrieval in `createClient`
- adjust server code to await the client

## Testing
- `npm run build` *(fails: ESLint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_686bbcfaf5f0832faea17f62cbe49a5c