### PR TITLE
Add env vars for recover email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ SMTP_PORT=465
 SMTP_USER=info@webu.hu
 SMTP_PASS=Hostarmada123.
 MFA_EMAIL_FROM=info@webu.hu
+LOGO_IMAGE_URL=https://your-cdn.com/logo.png
+LOGIN_LINK=http://localhost:3000/login

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ If you wish to just develop locally and not deploy to Vercel, [follow the steps 
    SMTP_USER=[YOUR SMTP USER]
    SMTP_PASS=[YOUR SMTP PASSWORD]
    MFA_EMAIL_FROM=[SENDER EMAIL ADDRESS]
+   LOGO_IMAGE_URL=[URL TO EMAIL LOGO IMAGE]
+   LOGIN_LINK=[URL FOR LOGIN PAGE]
    ```
 
    Both `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` can be found in [your Supabase project's API settings](https://supabase.com/dashboard/project/_?showConnect=true)

--- a/components/emails/RecoverMfaEmail.tsx
+++ b/components/emails/RecoverMfaEmail.tsx
@@ -29,7 +29,7 @@ export default function RecoverMfaEmail({
         <Container style={styles.container}>
           {/* Logo */}
           <Img
-            src="https://your-cdn.com/logo.png"
+            src={process.env.LOGO_IMAGE_URL ?? "https://your-cdn.com/logo.png"}
             alt="Your App"
             width="48"
             height="48"
@@ -60,7 +60,7 @@ export default function RecoverMfaEmail({
           {/* Call-to-Action */}
           <Button
             style={styles.button}
-            href="http://localhost:3000/login"
+            href={process.env.LOGIN_LINK ?? "http://localhost:3000/login"}
           >
             Go to Your Dashboard
           </Button>


### PR DESCRIPTION
## Summary
- add new LOGO_IMAGE_URL and LOGIN_LINK env vars
- document them in README
- reference env vars in RecoverMfaEmail

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bcb6b90c0832fafd3ced5f798852a