### PR TITLE
Improve MFA recovery action

### DIFF
--- a/lib/actions/mfa/recoverMfa.tsx
+++ b/lib/actions/mfa/recoverMfa.tsx
@@ -5,6 +5,7 @@ import { createAdminClient } from '@/lib/supabase/admin.server'
 import nodemailer from 'nodemailer'
 import { render } from '@react-email/render'
 import RecoverMfaEmail from '@/components/emails/RecoverMfaEmail'
+import React from 'react'
 
 // Define a clear result interface for type safety
 interface RecoverMfaResult {
@@ -13,67 +14,44 @@ interface RecoverMfaResult {
 }
 
 export const recoverMfa = async (): Promise<RecoverMfaResult> => {
-  // Use a try/catch block for robust error handling
   try {
-    // 1. Initialize Supabase clients within the action
+    // 1. Initialize Supabase clients
     const supabase = await createClient()
-    const supabaseAdmin = createAdminClient()
+    const admin = createAdminClient()
 
-    // 2. Get the authenticated user from the server client
-    // This is secure and automatically handles the session from the request context
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser()
-
-    if (userError || !user) {
-      console.error('MFA Recovery Error: User not authenticated.')
-      return { success: false, error: 'Authentication failed. Please log in again.' }
+    // 2. Fetch the currently authenticated user
+    const { data: { user }, error: userErr } = await supabase.auth.getUser()
+    if (userErr || !user) {
+      return { success: false, error: 'Not authenticated' }
     }
 
-    // 3. List and delete all existing TOTP factors for the user
-    // This requires the admin client to bypass RLS and MFA policies
-    const { data: listData, error: listError } =
-      await supabaseAdmin.auth.admin.mfa.listFactors({ userId: user.id })
-
-    if (listError) {
-      console.error(`MFA Recovery Error: Could not list factors for user ${user.id}`, listError)
-      return { success: false, error: 'Failed to retrieve existing MFA settings.' }
+    // 3. Remove any existing TOTP factors with the admin client
+    const { data: listData, error: listErr } =
+      await admin.auth.admin.mfa.listFactors({ userId: user.id })
+    if (listErr) {
+      return { success: false, error: listErr.message }
     }
-    
-    // Filter for only TOTP factors before attempting deletion
-    const totpFactors = listData.all.filter((f) => f.factor_type === 'totp');
-    
-    for (const factor of totpFactors) {
-      const { error: deleteError } = await supabaseAdmin.auth.admin.mfa.deleteFactor({
+    for (const f of listData.all.filter(f => f.factor_type === 'totp')) {
+      const { error: delErr } = await admin.auth.admin.mfa.deleteFactor({
         userId: user.id,
-        id: factor.id,
+        id: f.id,
       })
-      if (deleteError) {
-        console.error(`MFA Recovery Error: Could not delete factor ${factor.id} for user ${user.id}`, deleteError)
-        return { success: false, error: 'Failed to remove an old MFA setting.' }
-      }
+      if (delErr) return { success: false, error: delErr.message }
     }
 
-    // 4. Enroll a new TOTP factor for the user
-    const { data: enrollData, error: enrollError } =
-      await supabase.auth.mfa.enroll({
-        factorType: 'totp',
-      })
-
-    if (enrollError || !enrollData) {
-      console.error(`MFA Recovery Error: Could not enroll new factor for user ${user.id}`, enrollError)
-      return { success: false, error: 'Could not create a new MFA setup.' }
+    // 4. Generate a fresh TOTP factor for the user
+    const { data: enrollData, error: enrollErr } =
+      await admin.auth.admin.mfa.generateTOTP({ userId: user.id })
+    if (enrollErr || !enrollData) {
+      return { success: false, error: enrollErr?.message || 'Failed to generate MFA' }
     }
 
-    // 5. Configure SMTP transporter using environment variables
+    // 5. Configure the SMTP transporter
     const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, MFA_EMAIL_FROM, SUPPORT_EMAIL } = process.env
-
     if (!SMTP_HOST || !MFA_EMAIL_FROM) {
-      console.error('MFA Recovery Error: Missing required SMTP environment variables (SMTP_HOST, MFA_EMAIL_FROM)')
-      return { success: false, error: 'Server configuration error prevents sending email.' }
+      return { success: false, error: 'SMTP not configured' }
     }
-    
+
     const transporter = nodemailer.createTransport({
       host: SMTP_HOST,
       port: Number(SMTP_PORT ?? 587),
@@ -82,30 +60,38 @@ export const recoverMfa = async (): Promise<RecoverMfaResult> => {
         user: SMTP_USER,
         pass: SMTP_PASS,
       },
-      tls: {
-        rejectUnauthorized: false, // Use true in production with valid certs
-      },
+      tls: { rejectUnauthorized: false },
     })
 
-    // 6. Render the email template and send the email
-    const emailHtml = render(
+    try {
+      await transporter.verify()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return { success: false, error: `SMTP error: ${message}` }
+    }
+
+    // 6. Render and send the recovery email
+    const html = render(
       <RecoverMfaEmail
         qrCodeUrl={enrollData.totp.qr_code}
         supportEmail={SUPPORT_EMAIL || 'support@example.com'}
-      />
+      />,
     )
 
-    await transporter.sendMail({
-      from: `"${process.env.APP_NAME || 'Your App'} Support" <${MFA_EMAIL_FROM}>`,
-      to: user.email!,
-      subject: 'MFA Recovery for Your Account',
-      html: emailHtml,
-    })
-    
-    return { success: true }
-
-  } catch (error: any) {
-    console.error('An unexpected error occurred during MFA recovery:', error)
-    return { success: false, error: 'An unexpected server error occurred.' }
+    try {
+      await transporter.sendMail({
+        from: `"${process.env.APP_NAME || 'Your App'} Support" <${MFA_EMAIL_FROM}>`,
+        to: user.email ?? '',
+        subject: 'MFA Recovery for Your Account',
+        html,
+      })
+      return { success: true }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return { success: false, error: message }
+    }
+  } catch (err) {
+    console.error('MFA recovery failed', err)
+    return { success: false, error: 'Unexpected server error' }
   }
 }


### PR DESCRIPTION
## Summary
- rewrite the MFA recovery server action
- generate the recovery TOTP with the admin client and send via email

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars in other files)*
- `npx eslint lib/actions/mfa/recoverMfa.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686bd5a2d5fc832fb5a54cd89e10ec7a