### PR TITLE
Fix mail send call formatting

### DIFF
--- a/lib/actions/mfa.server.ts
+++ b/lib/actions/mfa.server.ts
@@ -118,7 +118,8 @@ export async function recoverMfa(): Promise<{ success: boolean; error?: string }
       from: `"${process.env.APP_NAME!}" <${process.env.MFA_EMAIL_FROM!}>`,
       to: user.email!,
       subject: 'Your Two-Factor Authentication Recovery',
-      html,});
+      html,
+    });
 
     return { success: true };
   } catch (err) {


### PR DESCRIPTION
## Summary
- format `sendMail` call in MFA recovery action

## Testing
- `npm run lint` *(fails: 'err' defined but never used and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686bec2e36a4832fb935b24437760cf8