### PR TITLE
Fix comment in supabase browser client

### DIFF
--- a/lib/supabase/browser.ts
+++ b/lib/supabase/browser.ts
@@ -1,6 +1,6 @@
 /* ─────────── lib/supabase/browser.ts ─────────── */
 'use client'                                         // browser bundle only
-import { createBrowserClient } from '@supabase/ssr'  // new     SDK :contentReference[oaicite:2]{index=2}
+import { createBrowserClient } from '@supabase/ssr'  // new     SDK
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from './utils'
 
 const supabase = createBrowserClient(


### PR DESCRIPTION
## Summary
- remove stray `contentReference` comment from `browser.ts`

## Testing
- `npm run lint` *(fails: 'err' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_686bec2fcd00832f84a606157cc44666