### PR TITLE
Add app name & support email env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,6 @@ MFA_EMAIL_FROM=info@webu.hu
 LOGO_IMAGE_URL=https://your-cdn.com/logo.png
 LOGIN_LINK=http://localhost:3000/login
 MFA_RECOVERY_LINK=http://localhost:3000/mfa-recovery
+APP_NAME=your-app-name
+SUPPORT_EMAIL=support@example.com
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ If you wish to just develop locally and not deploy to Vercel, [follow the steps 
    LOGO_IMAGE_URL=[URL TO EMAIL LOGO IMAGE]
    LOGIN_LINK=[URL FOR LOGIN PAGE]
    MFA_RECOVERY_LINK=http://localhost:3000/mfa-recovery
+   APP_NAME=[YOUR APP NAME]
+   SUPPORT_EMAIL=[SUPPORT EMAIL ADDRESS]
 
    ```
 


### PR DESCRIPTION
## Summary
- add `APP_NAME` and `SUPPORT_EMAIL` placeholders in `.env.example`
- reference these new env vars in setup instructions in README

## Testing
- `npm run lint` *(fails: 'no-unused-vars' and other warnings)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bec3be914832fafbb0bfaa8aa2f65