### PR TITLE
Fix MFA recovery error logs

### DIFF
--- a/lib/actions/mfa.server.ts
+++ b/lib/actions/mfa.server.ts
@@ -123,7 +123,7 @@ export async function recoverMfa(): Promise<{ success: boolean; error?: string }
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('MFA Recovery Failed SOP:', message);
+    console.error('MFA recovery failed:', message);
     return { success: false, error: message };
   }
 }

--- a/lib/actions/mfa/recoverMfa.tsx
+++ b/lib/actions/mfa/recoverMfa.tsx
@@ -82,7 +82,7 @@ export async function recoverMfa(): Promise<{ success: boolean; error?: string }
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'An unknown error occurred.';
-    console.error('MFA Recovery Failed S>DASS:', message);
+    console.error('MFA recovery failed:', message);
     return { success: false, error: message };
   }
 }


### PR DESCRIPTION
## Summary
- standardize error messages when MFA recovery fails

## Testing
- `npm run lint` *(fails: Button is defined but never used and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bec2ab1f4832fae89e3bf4196e400