### PR TITLE
Document setup prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,13 @@ If you wish to just develop locally and not deploy to Vercel, [follow the steps 
    cd with-supabase-app
    ```
 
-4. Rename `.env.example` to `.env.local` and update the following:
+4. Install dependencies before running development commands like `npm run dev` or `npm run lint`
+
+```bash
+npm install
+```
+
+5. Rename `.env.example` to `.env.local` and update the following:
 
    ```
    NEXT_PUBLIC_SUPABASE_URL=[INSERT SUPABASE PROJECT URL]
@@ -101,7 +107,7 @@ If you wish to just develop locally and not deploy to Vercel, [follow the steps 
    Both `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` can be found in [your Supabase project's API settings](https://supabase.com/dashboard/project/_?showConnect=true)
    The SMTP variables are used to send a recovery email containing a link to reset MFA if a user loses access to their authenticator device.
 
-5. You can now run the Next.js local development server:
+6. You can now run the Next.js local development server:
 
    ```bash
    npm run dev
@@ -109,7 +115,7 @@ If you wish to just develop locally and not deploy to Vercel, [follow the steps 
 
    The starter kit should now be running on [localhost:3000](http://localhost:3000/).
 
-6. This template comes with the default shadcn/ui style initialized. If you instead want other ui.shadcn styles, delete `components.json` and [re-install shadcn/ui](https://ui.shadcn.com/docs/installation/next)
+7. This template comes with the default shadcn/ui style initialized. If you instead want other ui.shadcn styles, delete `components.json` and [re-install shadcn/ui](https://ui.shadcn.com/docs/installation/next)
 
 > Check out [the docs for Local Development](https://supabase.com/docs/guides/getting-started/local-development) to also run Supabase locally.
 

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
## Summary
- recommend Node 18+ in `package.json`
- mention installing dependencies before `npm run dev` or `npm run lint`

## Testing
- `npm run lint` *(fails: errors from ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_686bec3234e4832fb21a968dafb25a97