### PR TITLE
Fix 2FA recovery flow to use Supabase token

### DIFF
--- a/lib/actions/mfa/generateNewMfaFromToken.ts
+++ b/lib/actions/mfa/generateNewMfaFromToken.ts
@@ -2,25 +2,14 @@
 'use server';
 
 // UPDATED: Import the Supabase server client creator
-import { createClient } from '@/lib/supabase/client'; 
-import speakeasy from 'speakeasy';
-import qrcode from 'qrcode';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
+import {
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  SUPABASE_SERVICE_ROLE_KEY,
+} from '@/lib/supabase/utils';
 
-// NOTE: You might have these types defined elsewhere, e.g., from Supabase codegen.
-// These are placeholders based on the previous Prisma schema.
-interface User {
-  id: string;
-  email: string;
-  // add other user properties as needed
-}
-
-interface MfaRecoveryToken {
-  id: string;
-  token: string;
-  expiresAt: Date;
-  userId: string;
-}
 
 
 // Define the expected response shape for type safety
@@ -49,80 +38,61 @@ export async function generateNewMfaFromToken(
     return { success: false, error: 'Invalid token provided.' };
   }
 
-  // Instantiate the Supabase client for server-side use
-  const supabase = createClient();
+  // Clients used to validate the token and perform MFA actions
+  const adminClient = createSupabaseClient(
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { persistSession: false, autoRefreshToken: false } }
+  );
+
+  const userClient = createSupabaseClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    global: { headers: { Authorization: `Bearer ${validation.data}` } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
 
   try {
-    // 2. Find the recovery token in the database using Supabase
-    const { data: recoveryToken, error: tokenError } = await supabase
-      .from('mfa_recovery_tokens') // Assumes table name is 'mfa_recovery_tokens'
-      .select('*')
-      .eq('token', validation.data)
-      .single<MfaRecoveryToken>();
-
-    if (tokenError || !recoveryToken) {
-      return { success: false, error: 'Recovery link is invalid.' };
-    }
-
-    // 3. Check if the token has expired
-    if (new Date() > new Date(recoveryToken.expiresAt)) {
-      // Clean up expired token
-      await supabase.from('mfa_recovery_tokens').delete().eq('id', recoveryToken.id);
-      return { success: false, error: 'Recovery link has expired. Please request a new one.' };
-    }
-
-    // 4. Find the associated user
-    const { data: user, error: userError } = await supabase
-        .from('users') // Assumes table name is 'users'
-        .select('*')
-        .eq('id', recoveryToken.userId)
-        .single<User>();
+    // 2. Validate the access token and retrieve the user
+    const {
+      data: { user },
+      error: userError,
+    } = await adminClient.auth.getUser(validation.data);
 
     if (userError || !user) {
-      return { success: false, error: 'User not found.' };
+      return {
+        success: false,
+        error: 'Invalid or expired token. Please request a new recovery link.',
+      };
     }
 
-    // 5. Generate a new MFA secret
-    const newSecret = speakeasy.generateSecret({
-      name: `YourAppName (${user.email})`, // Customize with your app name
+    // 3. Remove any existing TOTP factors for this user
+    const { data: factors, error: listErr } = await adminClient.auth.admin.mfa.listFactors({
+      userId: user.id,
     });
-
-    // 6. Update the user record with the new (unverified) secret
-    const { error: updateUserError } = await supabase
-        .from('users')
-        .update({
-            mfa_secret: newSecret.base32, // Assumes column name is 'mfa_secret'
-            is_mfa_enabled: false, // Assumes column name is 'is_mfa_enabled'
-        })
-        .eq('id', user.id);
-
-    if (updateUserError) {
-        throw updateUserError;
+    if (listErr) {
+      console.error('List factors error:', listErr);
+      return { success: false, error: 'Failed to reset existing factors.' };
+    }
+    for (const f of factors.factors.filter((f) => f.factor_type === 'totp')) {
+      const { error: delErr } = await adminClient.auth.admin.mfa.deleteFactor({
+        userId: user.id,
+        id: f.id,
+      });
+      if (delErr) {
+        console.error('Delete factor error:', delErr);
+        return { success: false, error: 'Failed to disable old authenticator.' };
+      }
     }
 
-    // 7. Generate the QR code data URL for the client
-    // The otpauthURL is a standard format that authenticator apps understand.
-    const otpauthUrl = speakeasy.otpauthURL({
-      secret: newSecret.base32,
-      label: encodeURIComponent(user.email ?? 'user'),
-      issuer: 'YourAppName', // Should be the name of your application
-      algorithm: 'SHA1',
+    // 4. Enroll a new TOTP factor using the user's token
+    const { data: enrollData, error: enrollErr } = await userClient.auth.mfa.enroll({
+      factorType: 'totp',
     });
+    if (enrollErr || !enrollData?.totp?.qr_code) {
+      console.error('Enroll MFA error:', enrollErr);
+      return { success: false, error: 'Failed to create new authenticator factor.' };
+    }
 
-    // We convert this URL into a Base64-encoded image (a "data URL").
-    // This data URL can be used directly as the `src` for an `<img>` tag on the client-side,
-    // just like in the component you provided. Example: <img src={qrCodeDataUrl} />
-    const qrCodeDataUrl = await qrcode.toDataURL(otpauthUrl);
-    
-    // 8. Invalidate the recovery token by deleting it to prevent reuse
-    await supabase.from('mfa_recovery_tokens').delete().eq('id', recoveryToken.id);
-
-    // 9. Return the QR code for the user to scan on the client.
-    // The client-side component will receive this `qrCode` and display it as an image.
-    return {
-      success: true,
-      qrCode: qrCodeDataUrl,
-    };
+    return { success: true, qrCode: enrollData.totp.qr_code };
 
   } catch (error) {
     console.error('MFA TOKEN GENERATION ERROR:', error);

--- a/lib/actions/mfa/recoverMfa.tsx
+++ b/lib/actions/mfa/recoverMfa.tsx
@@ -39,16 +39,6 @@ export async function recoverMfa(): Promise<{ success: boolean; error?: string }
       throw new Error('Not authenticated. This may be due to invalid cookies or an authentication issue.');
     }
 
-    const { data: listData, error: listErr } = await admin.auth.admin.mfa.listFactors({ userId: user.id });
-    if (listErr) throw listErr;
-
-    for (const f of listData.factors.filter(f => f.factor_type === 'totp')) {
-      const { error: delErr } = await admin.auth.admin.mfa.deleteFactor({ userId: user.id, id: f.id });
-      if (delErr) throw delErr;
-    }
-
-    const { data: enrollData, error: enrollErr } = await supabase.auth.mfa.enroll({ factorType: 'totp' });
-    if (enrollErr || !enrollData) throw enrollErr || new Error('Failed to generate a new MFA factor.');
 
     const { data: linkData, error: linkErr } = await admin.auth.admin.generateLink({
       email: user.email!,


### PR DESCRIPTION
## Summary
- handle MFA recovery via verified access token
- send recovery emails without pre-enrolling the factor

## Testing
- `npm test`
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bffbac99c832fae710d1556b6aaa2