### PR TITLE
Fix build when env vars missing

### DIFF
--- a/lib/supabase/browser.ts
+++ b/lib/supabase/browser.ts
@@ -1,12 +1,13 @@
 /* ─────────── lib/supabase/browser.ts ─────────── */
-'use client'                                         // browser bundle only
-import { createBrowserClient } from '@supabase/ssr'  // new     SDK
-import { SUPABASE_URL, SUPABASE_ANON_KEY } from './utils'
+"use client";
+import { createBrowserClient } from "@supabase/ssr";
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from "./utils";
 
-const supabase = createBrowserClient(
-  SUPABASE_URL,
-  SUPABASE_ANON_KEY,
-)                                                   // one socket, many hooks
+let supabase: ReturnType<typeof createBrowserClient> | undefined;
 
-export default supabase
-export function createClient() { return supabase }  // ⬅ legacy wrapper if you like
+export function createClient() {
+  if (!supabase) {
+    supabase = createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  }
+  return supabase;
+}


### PR DESCRIPTION
## Summary
- avoid running Supabase client creation during module load
- update MFA client utilities to create Supabase client lazily

## Testing
- `npm run lint`
- `npm test`
- `env -u NEXT_PUBLIC_SUPABASE_URL -u NEXT_PUBLIC_SUPABASE_ANON_KEY npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d0b424f88832fa69780ab61fb2f5c