### PR TITLE
Add Prisma-based MFA implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ You can enable MFA under **Settings** after signing in.
 Click **Enable 2FA**, scan the generated QR code in any authenticator app,
 then verify the one-time code to secure your account.
 
+### Prisma-backed MFA example
+
+If you prefer storing MFA secrets in your own database, this repo now includes a
+Prisma implementation under `lib/actions/prismaMfa` and `lib/mfaStorePrisma.ts`.
+After running `npx prisma migrate dev` and `npx prisma generate`, you can call
+`enrollMFA`, `verifyMFA`, `recoverMfa` and `completeRecovery` with the current
+user's ID from your session. Recovery emails are sent via the generic
+`sendEmail` helper.
+
 ## Demo
 
 You can view a fully working demo at [demo-nextjs-with-supabase.vercel.app](https://demo-nextjs-with-supabase.vercel.app/).

--- a/lib/actions/prismaMfa/completeRecovery.ts
+++ b/lib/actions/prismaMfa/completeRecovery.ts
@@ -1,0 +1,12 @@
+import { prisma } from '@/lib/prisma'
+import { clearMfa } from '@/lib/mfaStorePrisma'
+
+export async function completeRecovery(token: string): Promise<{ success: true } | { success: false; error: string }> {
+  const user = await prisma.user.findFirst({
+    where: { recoveryToken: token, recoveryExpires: { gt: new Date() } },
+  })
+  if (!user) return { success: false, error: 'Invalid or expired recovery link.' }
+
+  await clearMfa(user.id)
+  return { success: true }
+}

--- a/lib/actions/prismaMfa/enrollMfa.ts
+++ b/lib/actions/prismaMfa/enrollMfa.ts
@@ -1,0 +1,20 @@
+import speakeasy from 'speakeasy'
+import QRCode from 'qrcode'
+import { getUserById, saveSecret } from '@/lib/mfaStorePrisma'
+
+export async function enrollMFA(userId: string) {
+  const user = await getUserById(userId)
+  if (user.mfaEnabled && user.mfaSecret) {
+    return { alreadyEnrolled: true as const }
+  }
+
+  const secret = speakeasy.generateSecret({
+    name: `MyApp (${user.email})`,
+    length: 20,
+  })
+
+  await saveSecret(userId, secret.base32)
+  const qrCodeDataUrl = await QRCode.toDataURL(secret.otpauth_url!)
+
+  return { totp: { qr_code: qrCodeDataUrl } }
+}

--- a/lib/actions/prismaMfa/recoverMfa.ts
+++ b/lib/actions/prismaMfa/recoverMfa.ts
@@ -1,0 +1,19 @@
+import { randomUUID } from 'crypto'
+import { setRecoveryToken, getUserById } from '@/lib/mfaStorePrisma'
+import sendEmail from '../sendEmail'
+
+export async function recoverMfa(userId: string): Promise<{ success: true } | { success: false; error: string }> {
+  const token = randomUUID()
+  const expires = new Date(Date.now() + 60 * 60 * 1000)
+
+  await setRecoveryToken(userId, token, expires)
+
+  const link = `${process.env.APP_URL}/mfa/recover?token=${token}`
+  await sendEmail({
+    to: (await getUserById(userId)).email,
+    subject: 'Recover your MFA',
+    html: `<p>Click <a href="${link}">here</a> to reset your two-factor authentication. Expires in 1 hour.</p>`
+  })
+
+  return { success: true }
+}

--- a/lib/actions/prismaMfa/verifyMfa.ts
+++ b/lib/actions/prismaMfa/verifyMfa.ts
@@ -1,0 +1,29 @@
+import speakeasy from 'speakeasy'
+import { getUserById, enableMfa } from '@/lib/mfaStorePrisma'
+
+export async function verifyMFA({
+  userId,
+  verifyCode,
+}: {
+  userId: string
+  verifyCode: string
+}): Promise<{ success: true } | { success: false; error: string }> {
+  const user = await getUserById(userId)
+  if (!user.mfaSecret) {
+    return { success: false, error: 'MFA not initialized.' }
+  }
+
+  const valid = speakeasy.totp.verify({
+    secret: user.mfaSecret,
+    encoding: 'base32',
+    token: verifyCode,
+    window: 1,
+  })
+
+  if (!valid) {
+    return { success: false, error: 'Invalid TOTP code.' }
+  }
+
+  await enableMfa(userId)
+  return { success: true }
+}

--- a/lib/actions/sendEmail.ts
+++ b/lib/actions/sendEmail.ts
@@ -1,0 +1,24 @@
+import nodemailer from 'nodemailer'
+
+type Options = {
+  to: string
+  subject: string
+  html: string
+}
+
+export default async function sendEmail(opts: Options) {
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT),
+    secure: Number(process.env.SMTP_PORT) === 465,
+    auth: { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS },
+    tls: { rejectUnauthorized: false },
+  })
+
+  await transporter.sendMail({
+    from: `"${process.env.APP_NAME || 'Your App'}" <${process.env.MFA_EMAIL_FROM}>`,
+    to: opts.to,
+    subject: opts.subject,
+    html: opts.html,
+  })
+}

--- a/lib/mfaStorePrisma.ts
+++ b/lib/mfaStorePrisma.ts
@@ -1,0 +1,35 @@
+import { prisma } from './prisma'
+
+export async function getUserById(userId: string) {
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user) throw new Error('User not found')
+  return user
+}
+
+export async function saveSecret(userId: string, base32Secret: string) {
+  return prisma.user.update({
+    where: { id: userId },
+    data: { mfaSecret: base32Secret },
+  })
+}
+
+export async function enableMfa(userId: string) {
+  return prisma.user.update({
+    where: { id: userId },
+    data: { mfaEnabled: true, recoveryToken: null, recoveryExpires: null },
+  })
+}
+
+export async function setRecoveryToken(userId: string, token: string, expiresAt: Date) {
+  return prisma.user.update({
+    where: { id: userId },
+    data: { recoveryToken: token, recoveryExpires: expiresAt },
+  })
+}
+
+export async function clearMfa(userId: string) {
+  return prisma.user.update({
+    where: { id: userId },
+    data: { mfaEnabled: false, mfaSecret: null },
+  })
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,14 @@
+import { PrismaClient } from '@prisma/client'
+
+declare global {
+  // prevent multiple instances of PrismaClient in development
+  var prisma: PrismaClient | undefined
+}
+
+export const prisma =
+  global.prisma ||
+  new PrismaClient({
+    log: ['query', 'warn'],
+  })
+
+if (process.env.NODE_ENV !== 'production') global.prisma = prisma

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-  "name": "with-supabase-app",
+  "name": "supabase-two-factor-auth",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
         "@iconify/react": "^6.0.0",
+        "@prisma/client": "^5.12.0",
         "@radix-ui/react-checkbox": "^1.3.1",
         "@radix-ui/react-dropdown-menu": "^2.1.14",
         "@radix-ui/react-label": "^2.1.6",
@@ -42,6 +43,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.3.1",
         "postcss": "^8",
+        "prisma": "^5.12.0",
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5",
@@ -1609,6 +1611,74 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
+      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
+      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/fetch-engine": "5.22.0",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
+      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
+      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -8001,6 +8071,26 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
+      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/engines": "5.22.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
       }
     },
     "node_modules/prismjs": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-qr-code": "^2.0.18",
     "speakeasy": "^2.0.0",
     "tailwind-merge": "^3.3.0",
-    "zod": "^3.25.75"
+    "zod": "^3.25.75",
+    "@prisma/client": "^5.12.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -48,7 +49,8 @@
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "prisma": "^5.12.0"
   },
   "engines": {
     "node": ">=18"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,20 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id              String   @id @default(cuid())
+  email           String   @unique
+  hashedPassword  String
+  mfaEnabled      Boolean  @default(false)
+  mfaSecret       String?
+  recoveryToken   String?
+  recoveryExpires DateTime?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+}


### PR DESCRIPTION
## Summary
- provide Prisma schema for user with MFA fields
- add Prisma client helper and MFA store helpers
- implement MFA actions using Prisma including recovery
- add generic email helper
- document Prisma-backed MFA example
- add prisma dependencies

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e0b29a448832fbb0bc20cbec13471